### PR TITLE
Add CI_update_remote to auto-update plugintemplate

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -11,13 +11,13 @@ jobs:
       matrix:
         build_configuration: [Release, Debug]
         build_platform: [x64, Win32, ARM64]
-        
+
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
 
     - name: MSBuild of plugin dll
       working-directory: vs.proj\
@@ -25,21 +25,21 @@ jobs:
 
     - name: Archive artifacts for x64
       if: matrix.build_platform == 'x64' && matrix.build_configuration == 'Release'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: plugin_dll_x64
           path: bin64\NppPluginTemplate.dll
 
     - name: Archive artifacts for Win32
       if: matrix.build_platform == 'Win32' && matrix.build_configuration == 'Release'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: plugin_dll_x86
           path: bin\NppPluginTemplate.dll
 
     - name: Archive artifacts for ARM64
       if: matrix.build_platform == 'ARM64' && matrix.build_configuration == 'Release'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: plugin_dll_arm64
           path: arm64\NppPluginTemplate.dll

--- a/.github/workflows/CI_update_remote.yml
+++ b/.github/workflows/CI_update_remote.yml
@@ -1,0 +1,102 @@
+name: CI_update_remote
+
+on:
+  # on demand, from Actions tab
+  workflow_dispatch:
+
+  # on schedule (using cron syntax)
+  schedule:
+    - cron: "0 0 1 * *" #< first day of every month at 00:00 UTC
+
+jobs:
+  update:
+    # This job would annoy people who fork the template, or if plugintemplate ever becomes a "template repository"
+    #   if someone _wants_ this, change the name to match their own fork or project
+    if: ${{ github.repository_name == 'notepad-plus-plus/plugintemplate' }}
+
+    permissions:
+      packages: write
+      contents: write
+
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 6
+      matrix:
+        build_configuration: [Release]
+        build_platform: [x64]
+
+    steps:
+    - name: Checkout plugintemplate repo
+      uses: actions/checkout@v4
+
+    - name: Checkout N++ repo
+      uses: actions/checkout@v4
+      with:
+        repository: notepad-plus-plus/notepad-plus-plus
+        path: npp_repo
+
+    - name: Diff the hashes
+      id: diff_step
+      run: |
+        # start assuming no differences
+        $anyDifference = $false
+        #
+        # scintilla hashes: for plugintemplate (hps) and npp (hns)
+        #
+        $fps = "src\Scintilla.h"
+        $fns = "npp_repo\scintilla\include\Scintilla.h"
+        $hps = Get-FileHash $fps -Algorithm SHA256 | Select-Object -ExpandProperty Hash
+        $hns = Get-FileHash $fns -Algorithm SHA256 | Select-Object -ExpandProperty Hash
+        if ($hps -ne $hns) {
+            $anyDifference = $true
+            Copy-Item -path $fns -destination $fps -force
+        }
+        #
+        # Notepad_plus_msgs.h hashes: for plugintemplate (hpn) and npp (hnn)
+        $fpn = "src\Notepad_plus_msgs.h"
+        $fnn = "npp_repo\PowerEditor\src\MISC\PluginsManager\Notepad_plus_msgs.h"
+        $hpn = Get-FileHash $fpn -Algorithm SHA256 | Select-Object -ExpandProperty Hash
+        $hnn = Get-FileHash $fnn -Algorithm SHA256 | Select-Object -ExpandProperty Hash
+        if ($hpn -ne $hnn) {
+            $anyDifference = $true
+            Copy-Item -path $fnn -destination $fpn -force
+        }
+        #
+        # use  GITHUB_OUTPUT to propagate a value that will be able to control the conditional on a future step
+        if ($anyDifference) {
+            "ANY_DIFFERENCE=True" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        }
+        #
+        # Store the date:
+        $dateNow = (Get-Date).ToString("yyyy_MMMM_dd")
+        echo "CHANGE DATE will be $dateNow"
+        "CHANGE_DATE=$dateNow" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        #
+        # get rid of the extra hierarchy now that the hash
+        Remove-Item .\npp_repo -Force -Recurse -ErrorAction SilentlyContinue
+        #
+        git status
+
+    - name: If ANY_DIFFERENCE then add MSBuild to PATH
+      if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+      uses: microsoft/setup-msbuild@v1
+
+    - name: If ANY_DIFFERENCE then run MSBuild of plugin dll
+      if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+      working-directory: vs.proj\
+      run: msbuild NppPluginTemplate.vcxproj /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}"
+
+    - name: Commit any updates to the repo
+      if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: Updating plugintemplate based on most recent N++ repo (${{ steps.diff_step.outputs.CHANGE_DATE }})
+
+    - name: Release
+      if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+      uses: elgohr/Github-Release-Action@v5
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        title: Plugin Template for Notepad++ release v${{ steps.diff_step.outputs.CHANGE_DATE }}.${{github.run_number}}.${{github.run_attempt}}
+        tag: v${{ steps.diff_step.outputs.CHANGE_DATE }}.${{github.run_number}}.${{github.run_attempt}}

--- a/.github/workflows/CI_update_remote.yml
+++ b/.github/workflows/CI_update_remote.yml
@@ -15,15 +15,9 @@ jobs:
     if: ${{ github.repository_name == 'notepad-plus-plus/plugintemplate' }}
 
     permissions:
-      packages: write
       contents: write
 
     runs-on: windows-latest
-    strategy:
-      max-parallel: 6
-      matrix:
-        build_configuration: [Release]
-        build_platform: [x64]
 
     steps:
     - name: Checkout plugintemplate repo
@@ -34,6 +28,7 @@ jobs:
       with:
         repository: notepad-plus-plus/notepad-plus-plus
         path: npp_repo
+        filter: 'blob:none'
 
     - name: Diff the hashes
       id: diff_step
@@ -71,6 +66,7 @@ jobs:
         $dateNow = (Get-Date).ToString("yyyy_MMMM_dd")
         echo "CHANGE DATE will be $dateNow"
         "CHANGE_DATE=$dateNow" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        "HEAD_REF=$(git --git-dir=npp_repo/.git describe --always '@')" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         #
         # get rid of the extra hierarchy now that the hash
         Remove-Item .\npp_repo -Force -Recurse -ErrorAction SilentlyContinue
@@ -79,24 +75,29 @@ jobs:
 
     - name: If ANY_DIFFERENCE then add MSBuild to PATH
       if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
 
     - name: If ANY_DIFFERENCE then run MSBuild of plugin dll
       if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
       working-directory: vs.proj\
-      run: msbuild NppPluginTemplate.vcxproj /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}"
+      run: |
+        foreach ($target in ('Win32', 'x64', 'ARM64'))
+        {
+            msbuild NppPluginTemplate.vcxproj /m /p:configuration=Release /p:platform="$target"
+        }
 
     - name: Commit any updates to the repo
       if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
-        commit_message: Updating plugintemplate based on most recent N++ repo (${{ steps.diff_step.outputs.CHANGE_DATE }})
+        # GitHub will auto-link the upstream ref to the corresponding commit
+        commit_message: Sync template with notepad-plus-plus/notepad-plus-plus@${{ steps.diff_step.outputs.HEAD_REF }}
 
     - name: Release
       if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
-      uses: elgohr/Github-Release-Action@v5
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v2
       with:
-        title: Plugin Template for Notepad++ release v${{ steps.diff_step.outputs.CHANGE_DATE }}.${{github.run_number}}.${{github.run_attempt}}
-        tag: v${{ steps.diff_step.outputs.CHANGE_DATE }}.${{github.run_number}}.${{github.run_attempt}}
+        name: Plugin Template for Notepad++ release v${{ steps.diff_step.outputs.CHANGE_DATE }}.${{github.run_number}}.${{github.run_attempt}}
+        tag_name: v${{ steps.diff_step.outputs.CHANGE_DATE }}.${{github.run_number}}.${{github.run_attempt}}
+        target_commitish: ${{ github.ref_name }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ vs.proj/Debug
 vs.proj/Release
 vs.proj/x64
 vs.proj/ARM64
+vs.proj/NppPlugi.*
 vs.proj/NppPluginTemplate.opensdf
 vs.proj/NppPluginTemplate.exp
 vs.proj/NppPluginTemplate.lib


### PR DESCRIPTION
Runs once a month, or on-demand with the workflow_dispatch

Details:
- Brings in Notepad_plus_msgs.h and Scintilla.h from N++ repo, if needed
- Automatically tags/releases after an update

resolves #13 