### PR TITLE
Add example workflows with a README

### DIFF
--- a/.github/.exampleWorkflows/CI_update_remote_both.yml
+++ b/.github/.exampleWorkflows/CI_update_remote_both.yml
@@ -1,0 +1,122 @@
+name: CI_update_remote_both
+
+on:
+  # on demand, from Actions tab
+  workflow_dispatch:
+
+  # on schedule (using cron syntax)
+  schedule:
+    - cron: "0 0 1 * *" #< on the first day of every month, at 00:00 UTC
+
+jobs:
+  update:
+    permissions:
+      contents: write
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout plugintemplate repo
+      uses: actions/checkout@v4
+
+    - name: Checkout N++ repo
+      uses: actions/checkout@v4
+      with:
+        repository: notepad-plus-plus/notepad-plus-plus
+        path: npp_repo
+        filter: 'blob:none'
+
+    - name: Diff the hashes
+      id: diff_step
+      run: |
+        # start assuming no differences
+        $anyDifference = $false
+        #
+        #### Always trigger build on workflow_dispatch
+        #
+        if("${{ github.event_name }}" -eq "workflow_dispatch") {
+            $anyDifference = $true
+        }
+        #
+        # Define the local_path => upstream_path pairs
+        #
+        $pairs = @{
+            "src\\Scintilla.h" = "npp_repo\\scintilla\\include\\Scintilla.h"
+            "src\\Sci_Position.h" = "npp_repo\\scintilla\\include\\Sci_Position.h"
+            "src\\Notepad_plus_msgs.h" = "npp_repo\\PowerEditor\\src\\MISC\\PluginsManager\\Notepad_plus_msgs.h"
+            "src\\PluginInterface.h" = "npp_repo\\PowerEditor\\src\\MISC\\PluginsManager\\PluginInterface.h"
+            "src\\menuCmdID.h" = "npp_repo\\PowerEditor\\src\\menuCmdID.h"
+            "src\\DockingFeature\\Docking.h" = "npp_repo\\PowerEditor\\src\\WinControls\\DockingWnd\\Docking.h"
+            "src\\DockingFeature\\dockingResource.h" = "npp_repo\\PowerEditor\\src\\WinControls\\DockingWnd\\dockingResource.h"
+            ##
+            ### The following might be useful to plugin developers, but may require changes to make them compatible
+            ###     as such, they are listed for reference, but not included as part of the automatic update
+            ###     of the template
+            ##
+            #"src\\DockingFeature\\DockingDlgInterface.h" = "npp_repo\\PowerEditor\\src\\WinControls\\DockingWnd\\DockingDlgInterface.h"
+            #"src\\DockingFeature\\StaticDialog.h" = "npp_repo\\PowerEditor\\src\\WinControls\\StaticDialog\\StaticDialog.h"
+            #"src\\DockingFeature\\StaticDialog.cpp" = "npp_repo\\PowerEditor\\src\\WinControls\\StaticDialog\\StaticDialog.cpp"
+            #"src\\DockingFeature\\Window.h" = "npp_repo\\PowerEditor\\src\\WinControls\\Window.h"
+            #"src\\DockingFeature\\GoToLineDlg.cpp" = "npp_repo\\PowerEditor\\src\\ScintillaComponent\\GoToLineDlg.cpp"
+            #"src\\DockingFeature\\GoToLineDlg.h" = "npp_repo\\PowerEditor\\src\\ScintillaComponent\\GoToLineDlg.h"
+        }
+        #
+        # loop over each pair, calculate hash of each, and copy any files that are different
+        #
+        ForEach ($local_path in $pairs.Keys) {
+            $upstream_path = $pairs[$local_path]
+            $local_hash = Get-FileHash $local_path -Algorithm SHA256 | Select-Object -ExpandProperty Hash
+            $upstream_hash = Get-FileHash $upstream_path -Algorithm SHA256 | Select-Object -ExpandProperty Hash
+            Write-Output "$local_hash :: hash($local_path)"
+            Write-Output "$upstream_hash :: hash($upstream_path)"
+            if ($local_hash -ne $upstream_hash) {
+                $anyDifference = $true
+                Copy-Item -Path $upstream_path -destination $local_path -Force
+                Write-Output "hashes differed, so copied file"
+            }
+        }
+        #
+        # use  GITHUB_OUTPUT to propagate a value that will be able to control the conditional on a future step
+        if ($anyDifference) {
+            "ANY_DIFFERENCE=True" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        }
+        #
+        # Store the date and head reference for use in subsequent steps
+        $dateNow = (Get-Date).ToString("yyyy_MMMM_dd")
+        echo "CHANGE DATE will be $dateNow"
+        "CHANGE_DATE=$dateNow" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        "HEAD_REF=$(git --git-dir=npp_repo/.git describe --always '@')" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        #
+        # get rid of the extra hierarchy now that everything necessary has been copied
+        Remove-Item .\npp_repo -Force -Recurse -ErrorAction SilentlyContinue
+        #
+        git status
+
+    - name: If ANY_DIFFERENCE then add MSBuild to PATH
+      if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+      uses: microsoft/setup-msbuild@v2
+
+    - name: If ANY_DIFFERENCE then run MSBuild of plugin dll
+      if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+      working-directory: vs.proj\
+      run: |
+        foreach ($target in ('Win32', 'x64', 'ARM64'))
+        {
+            msbuild NppPluginTemplate.vcxproj /m /p:configuration=Release /p:platform="$target"
+        }
+
+    - name: Commit any updates to the repo
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        # GitHub will auto-link the upstream ref to the corresponding commit
+        commit_message: Sync template with notepad-plus-plus/notepad-plus-plus@${{ steps.diff_step.outputs.HEAD_REF }}
+
+    # un-comment the Release section if you want to trigger a release of your plugin based solely on the updates from Notepad++ repo
+    #- name: Release
+    #  if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+    #  uses: softprops/action-gh-release@v2
+    #  with:
+    #    name: Plugin Template for Notepad++ release v${{ steps.diff_step.outputs.CHANGE_DATE }}.${{github.run_number}}.${{github.run_attempt}}
+    #    tag_name: v${{ steps.diff_step.outputs.CHANGE_DATE }}.${{github.run_number}}.${{github.run_attempt}}
+    #    target_commitish: ${{ github.ref_name }}
+    #    token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/.exampleWorkflows/CI_update_remote_ondemand.yml
+++ b/.github/.exampleWorkflows/CI_update_remote_ondemand.yml
@@ -1,0 +1,118 @@
+name: CI_update_remote_ondemand
+
+on:
+  # on demand, from Actions tab
+  workflow_dispatch:
+
+jobs:
+  update:
+    permissions:
+      contents: write
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout plugintemplate repo
+      uses: actions/checkout@v4
+
+    - name: Checkout N++ repo
+      uses: actions/checkout@v4
+      with:
+        repository: notepad-plus-plus/notepad-plus-plus
+        path: npp_repo
+        filter: 'blob:none'
+
+    - name: Diff the hashes
+      id: diff_step
+      run: |
+        # start assuming no differences
+        $anyDifference = $false
+        #
+        #### Always trigger build on workflow_dispatch
+        #
+        if("${{ github.event_name }}" -eq "workflow_dispatch") {
+            $anyDifference = $true
+        }
+        #
+        # Define the local_path => upstream_path pairs
+        #
+        $pairs = @{
+            "src\\Scintilla.h" = "npp_repo\\scintilla\\include\\Scintilla.h"
+            "src\\Sci_Position.h" = "npp_repo\\scintilla\\include\\Sci_Position.h"
+            "src\\Notepad_plus_msgs.h" = "npp_repo\\PowerEditor\\src\\MISC\\PluginsManager\\Notepad_plus_msgs.h"
+            "src\\PluginInterface.h" = "npp_repo\\PowerEditor\\src\\MISC\\PluginsManager\\PluginInterface.h"
+            "src\\menuCmdID.h" = "npp_repo\\PowerEditor\\src\\menuCmdID.h"
+            "src\\DockingFeature\\Docking.h" = "npp_repo\\PowerEditor\\src\\WinControls\\DockingWnd\\Docking.h"
+            "src\\DockingFeature\\dockingResource.h" = "npp_repo\\PowerEditor\\src\\WinControls\\DockingWnd\\dockingResource.h"
+            ##
+            ### The following might be useful to plugin developers, but may require changes to make them compatible
+            ###     as such, they are listed for reference, but not included as part of the automatic update
+            ###     of the template
+            ##
+            #"src\\DockingFeature\\DockingDlgInterface.h" = "npp_repo\\PowerEditor\\src\\WinControls\\DockingWnd\\DockingDlgInterface.h"
+            #"src\\DockingFeature\\StaticDialog.h" = "npp_repo\\PowerEditor\\src\\WinControls\\StaticDialog\\StaticDialog.h"
+            #"src\\DockingFeature\\StaticDialog.cpp" = "npp_repo\\PowerEditor\\src\\WinControls\\StaticDialog\\StaticDialog.cpp"
+            #"src\\DockingFeature\\Window.h" = "npp_repo\\PowerEditor\\src\\WinControls\\Window.h"
+            #"src\\DockingFeature\\GoToLineDlg.cpp" = "npp_repo\\PowerEditor\\src\\ScintillaComponent\\GoToLineDlg.cpp"
+            #"src\\DockingFeature\\GoToLineDlg.h" = "npp_repo\\PowerEditor\\src\\ScintillaComponent\\GoToLineDlg.h"
+        }
+        #
+        # loop over each pair, calculate hash of each, and copy any files that are different
+        #
+        ForEach ($local_path in $pairs.Keys) {
+            $upstream_path = $pairs[$local_path]
+            $local_hash = Get-FileHash $local_path -Algorithm SHA256 | Select-Object -ExpandProperty Hash
+            $upstream_hash = Get-FileHash $upstream_path -Algorithm SHA256 | Select-Object -ExpandProperty Hash
+            Write-Output "$local_hash :: hash($local_path)"
+            Write-Output "$upstream_hash :: hash($upstream_path)"
+            if ($local_hash -ne $upstream_hash) {
+                $anyDifference = $true
+                Copy-Item -Path $upstream_path -destination $local_path -Force
+                Write-Output "hashes differed, so copied file"
+            }
+        }
+        #
+        # use  GITHUB_OUTPUT to propagate a value that will be able to control the conditional on a future step
+        if ($anyDifference) {
+            "ANY_DIFFERENCE=True" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        }
+        #
+        # Store the date and head reference for use in subsequent steps
+        $dateNow = (Get-Date).ToString("yyyy_MMMM_dd")
+        echo "CHANGE DATE will be $dateNow"
+        "CHANGE_DATE=$dateNow" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        "HEAD_REF=$(git --git-dir=npp_repo/.git describe --always '@')" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        #
+        # get rid of the extra hierarchy now that everything necessary has been copied
+        Remove-Item .\npp_repo -Force -Recurse -ErrorAction SilentlyContinue
+        #
+        git status
+
+    - name: If ANY_DIFFERENCE then add MSBuild to PATH
+      if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+      uses: microsoft/setup-msbuild@v2
+
+    - name: If ANY_DIFFERENCE then run MSBuild of plugin dll
+      if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+      working-directory: vs.proj\
+      run: |
+        foreach ($target in ('Win32', 'x64', 'ARM64'))
+        {
+            msbuild NppPluginTemplate.vcxproj /m /p:configuration=Release /p:platform="$target"
+        }
+
+    - name: Commit any updates to the repo
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        # GitHub will auto-link the upstream ref to the corresponding commit
+        commit_message: Sync template with notepad-plus-plus/notepad-plus-plus@${{ steps.diff_step.outputs.HEAD_REF }}
+
+    # un-comment the Release section if you want to trigger a release of your plugin based solely on the updates from Notepad++ repo
+    #- name: Release
+    #  if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+    #  uses: softprops/action-gh-release@v2
+    #  with:
+    #    name: Plugin Template for Notepad++ release v${{ steps.diff_step.outputs.CHANGE_DATE }}.${{github.run_number}}.${{github.run_attempt}}
+    #    tag_name: v${{ steps.diff_step.outputs.CHANGE_DATE }}.${{github.run_number}}.${{github.run_attempt}}
+    #    target_commitish: ${{ github.ref_name }}
+    #    token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/.exampleWorkflows/CI_update_remote_schedule.yml
+++ b/.github/.exampleWorkflows/CI_update_remote_schedule.yml
@@ -1,0 +1,119 @@
+name: CI_update_remote_schedule
+
+on:
+  # on schedule (using cron syntax)
+  schedule:
+    - cron: "0 0 1 * *" #< on the first day of every month, at 00:00 UTC
+
+jobs:
+  update:
+    permissions:
+      contents: write
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout plugintemplate repo
+      uses: actions/checkout@v4
+
+    - name: Checkout N++ repo
+      uses: actions/checkout@v4
+      with:
+        repository: notepad-plus-plus/notepad-plus-plus
+        path: npp_repo
+        filter: 'blob:none'
+
+    - name: Diff the hashes
+      id: diff_step
+      run: |
+        # start assuming no differences
+        $anyDifference = $false
+        #
+        #### Always trigger build on workflow_dispatch
+        #
+        if("${{ github.event_name }}" -eq "workflow_dispatch") {
+            $anyDifference = $true
+        }
+        #
+        # Define the local_path => upstream_path pairs
+        #
+        $pairs = @{
+            "src\\Scintilla.h" = "npp_repo\\scintilla\\include\\Scintilla.h"
+            "src\\Sci_Position.h" = "npp_repo\\scintilla\\include\\Sci_Position.h"
+            "src\\Notepad_plus_msgs.h" = "npp_repo\\PowerEditor\\src\\MISC\\PluginsManager\\Notepad_plus_msgs.h"
+            "src\\PluginInterface.h" = "npp_repo\\PowerEditor\\src\\MISC\\PluginsManager\\PluginInterface.h"
+            "src\\menuCmdID.h" = "npp_repo\\PowerEditor\\src\\menuCmdID.h"
+            "src\\DockingFeature\\Docking.h" = "npp_repo\\PowerEditor\\src\\WinControls\\DockingWnd\\Docking.h"
+            "src\\DockingFeature\\dockingResource.h" = "npp_repo\\PowerEditor\\src\\WinControls\\DockingWnd\\dockingResource.h"
+            ##
+            ### The following might be useful to plugin developers, but may require changes to make them compatible
+            ###     as such, they are listed for reference, but not included as part of the automatic update
+            ###     of the template
+            ##
+            #"src\\DockingFeature\\DockingDlgInterface.h" = "npp_repo\\PowerEditor\\src\\WinControls\\DockingWnd\\DockingDlgInterface.h"
+            #"src\\DockingFeature\\StaticDialog.h" = "npp_repo\\PowerEditor\\src\\WinControls\\StaticDialog\\StaticDialog.h"
+            #"src\\DockingFeature\\StaticDialog.cpp" = "npp_repo\\PowerEditor\\src\\WinControls\\StaticDialog\\StaticDialog.cpp"
+            #"src\\DockingFeature\\Window.h" = "npp_repo\\PowerEditor\\src\\WinControls\\Window.h"
+            #"src\\DockingFeature\\GoToLineDlg.cpp" = "npp_repo\\PowerEditor\\src\\ScintillaComponent\\GoToLineDlg.cpp"
+            #"src\\DockingFeature\\GoToLineDlg.h" = "npp_repo\\PowerEditor\\src\\ScintillaComponent\\GoToLineDlg.h"
+        }
+        #
+        # loop over each pair, calculate hash of each, and copy any files that are different
+        #
+        ForEach ($local_path in $pairs.Keys) {
+            $upstream_path = $pairs[$local_path]
+            $local_hash = Get-FileHash $local_path -Algorithm SHA256 | Select-Object -ExpandProperty Hash
+            $upstream_hash = Get-FileHash $upstream_path -Algorithm SHA256 | Select-Object -ExpandProperty Hash
+            Write-Output "$local_hash :: hash($local_path)"
+            Write-Output "$upstream_hash :: hash($upstream_path)"
+            if ($local_hash -ne $upstream_hash) {
+                $anyDifference = $true
+                Copy-Item -Path $upstream_path -destination $local_path -Force
+                Write-Output "hashes differed, so copied file"
+            }
+        }
+        #
+        # use  GITHUB_OUTPUT to propagate a value that will be able to control the conditional on a future step
+        if ($anyDifference) {
+            "ANY_DIFFERENCE=True" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        }
+        #
+        # Store the date and head reference for use in subsequent steps
+        $dateNow = (Get-Date).ToString("yyyy_MMMM_dd")
+        echo "CHANGE DATE will be $dateNow"
+        "CHANGE_DATE=$dateNow" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        "HEAD_REF=$(git --git-dir=npp_repo/.git describe --always '@')" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        #
+        # get rid of the extra hierarchy now that everything necessary has been copied
+        Remove-Item .\npp_repo -Force -Recurse -ErrorAction SilentlyContinue
+        #
+        git status
+
+    - name: If ANY_DIFFERENCE then add MSBuild to PATH
+      if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+      uses: microsoft/setup-msbuild@v2
+
+    - name: If ANY_DIFFERENCE then run MSBuild of plugin dll
+      if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+      working-directory: vs.proj\
+      run: |
+        foreach ($target in ('Win32', 'x64', 'ARM64'))
+        {
+            msbuild NppPluginTemplate.vcxproj /m /p:configuration=Release /p:platform="$target"
+        }
+
+    - name: Commit any updates to the repo
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        # GitHub will auto-link the upstream ref to the corresponding commit
+        commit_message: Sync template with notepad-plus-plus/notepad-plus-plus@${{ steps.diff_step.outputs.HEAD_REF }}
+
+    # un-comment the Release section if you want to trigger a release of your plugin based solely on the updates from Notepad++ repo
+    #- name: Release
+    #  if: ${{steps.diff_step.outputs.ANY_DIFFERENCE}}
+    #  uses: softprops/action-gh-release@v2
+    #  with:
+    #    name: Plugin Template for Notepad++ release v${{ steps.diff_step.outputs.CHANGE_DATE }}.${{github.run_number}}.${{github.run_attempt}}
+    #    tag_name: v${{ steps.diff_step.outputs.CHANGE_DATE }}.${{github.run_number}}.${{github.run_attempt}}
+    #    target_commitish: ${{ github.ref_name }}
+    #    token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/.exampleWorkflows/README.md
+++ b/.github/.exampleWorkflows/README.md
@@ -1,0 +1,54 @@
+# Example Workflows
+
+The [`.github/workflows`](../workflows) directory contains [`.github/workflows/CI_update_remote.yml` workflow](../workflows/CI_update_remote.yml), which listens for a specific command from the central Notepad++ repository, so that the plugintemplate can correctly keep certain files in sync with updates from Notepad++.  As a plugin author, that command will, unfortunately, not be sent to use (it's a resource-prohibitive procedure to notify _every_ plugin author, or even every plugin author who "subscribes", so it was decided to not be done).  That workflow is set to _not_ run when someone creates a repo based on this template.
+
+Since that workflow won't work for you, feel free to delete [`.github/workflows/CI_update_remote.yml` workflow](../workflows/CI_update_remote.yml) -- though, since it won't run unless the repo matches `npp-plugins/plugintemplate` and it receives a message from the Notepad++ repo (which it won't), you don't actually have to do anything to stop it from running.
+
+However, the good news is that, as a plugin author, you can use a _similar_ workflow to update those files in your plugin's repository, whether you want to do it on a schedule ("every month" or "every day"), or just on-demand (you can manually trigger it to check for updates), or both.  This directory contains an example of each of the three, and the sections below describe each one.  To use one of these examples, copy it into the [`.github/workflows`](../workflows) directory, and edit the file as described below to customize the behavior.
+
+Do not run these workflows if you customize any of the files mentioned in the "Other details", because this workflow will overwrite those anytime they are different in your repository compared to the main repository, whether it's caused by an upstream edit or by a customization on your end.
+
+## Scheduled Updates: `CI_update_remote_schedule.yml`
+
+If you want to check for updates from the Notepad++ repository on a fixed schedule, you can copy `CI_update_remote_schedule.yml` to [`.github/workflows`](../workflows).
+
+By default, it will check once per month, using the syntax
+```
+  # on schedule (using cron syntax)
+  schedule:
+    - cron: "0 0 1 * *" #< the first day of every month, at 00:00 UTC
+```
+
+The `cron: ...` line uses [crontab syntax](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07), and here are a few examples:
+
+```
+    - cron: "0 0 1 * *" #< the first day of every month, at 00:00 UTC
+    - cron: "0 0 * * *" #< every day at 00:00 UTC
+    - cron: "23 13 1,15 * *" #< the first and fifteenth of every month, at 13:23 UTC
+```
+You can feel free to set it to whatever time and schedule you desire (keeping in mind that GitHub might not appreciate you running this multiple times per day (ignoring the fact that it would be pretty useless, since the files don't change very often)).  Really, once a month should be sufficient for scheduled updates.
+
+## On-Demand Updates: `CI_update_remote_ondemand.yml`
+
+If you only want to check for updates from the Notepad++ repository when you feel like it, you can copy `CI_update_remote_ondemand.yml` to [`.github/workflows`](../workflows). It doesn't need any editing to make it available.
+
+To request the update, navigate to your repo's **Action** tab, select `CI_update_remote_ondemand`, and use the **Run workflow** button to run the workflow.
+
+## Both: `CI_update_remote_both.yml`
+
+If you want to check for updates from the Notepad++ repository on a fixed schedule or on demand, you can copy `CI_update_remote_both.yml` to [`.github/workflows`](../workflows).  You can customize the schedule as per the instructions above.
+
+## Other details
+
+By default, these actions check a specific list of files:
+- `PluginInterface.h` and `Notepad_plus_msgs.h` and `menuCmdID.h` define the interface with the main Notepad++ application.
+- `Docking.h` and `dockingResource.h` define extras needed when you want to have one or more of your windows dock with Notepad++.
+- `Scintilla.h` and `Sci_Position.h` define the interface with the Scintilla library, so your plugin can send messages to the view1 and view2 editor panels.
+
+If you want it to check other files, you can edit the `$pair` associative array to include the other files.  It is up to you to ensure that copying those files directly from the Notepad++ source code will be compatible with your plugin.  (You can feel free to edit the workflow, so if you want to automate some procedure to automatically apply edits compared to the file that you copy, that is your prerogative.)
+
+The workflow copies the new files into your repository, builds them, and (if it builds okay), commits to your repository.  If there are errors during the build, you can look at the error messages to see where things went wrong.  (If you want to change the order, you could have it commit _before_ it builds, which makes sure you have the new files; then, if it fails, you could then debug your code to figure out why the new files are incompatible.  If you don't change the order, you could manually grab the files, and do your debug locally before committing both your changes and the new files.)
+
+### Automatic Release
+
+There is a minuscule chance that you might want this workflow to automatically create a GitHub release of your plugin.  Since we figured out the sequence for doing the plugintemplate release, that section is shared at the end of the workflow, but it's commented out.  Uncomment that section if you want the automatic-release feature.


### PR DESCRIPTION
gives examples of how to keep a plugin repo up-to-date with the latest files from Notepad++/Scintilla which define the communication and interface